### PR TITLE
FREYA-914: Add pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,22 @@
+### 📋 Summary
+<!-- Briefly describe WHAT and WHY of this PR -->
+This PR ...
+ 
+### 🛠️ Changes Made
+<!-- One-liners or bullet points -->
+- 
+
+### 🔍 Notes for Reviewers
+<!-- Tips, edge cases, or test instructions -->
+ 
+### ✅ Checklist
+- [ ] PR title follows the pattern: `FREYA-XXXX: Clear and short description`
+- [ ] Jira / Github issue is linked
+- [ ] Assignee is selected
+- [ ] Code and content adhere to [conventions](https://scilifelab.atlassian.net/wiki/spaces/CDP2/pages/1909424133/Guidelines+for+the+portal+content)
+- [ ] Automated checks pass
+- [ ] Reviewer is selected when the PR is marked as ready for review
+
+### 🔗 Jira Issue
+<!-- Example: FREYA-914 -->
+Closes: [FREYA-XXXX](https://scilifelab.atlassian.net/browse/FREYA-XXXX)


### PR DESCRIPTION
### 📋 Summary
This PR adds a pull request template to provide guidelines and improve uniformity of our PRs.
 
### 🛠️ Changes Made
- Add `pull_request_template.md` in `.github/`

### 🔍 Notes for Reviewers
I'm not sure this can be tested by creating a new PR as it is not in the default branch yet.
But it will look exactly like this description with placeholders instead of the PR specific text.

### ✅ Checklist
- [x] PR title follows the pattern: `FREYA-XXXX: Clear and short description`
- [x] Jira / Github issue is linked
- [x] Assignee is selected
- [x] Code and content adhere to [conventions](https://scilifelab.atlassian.net/wiki/spaces/CDP2/pages/1909424133/Guidelines+for+the+portal+content)
- [x] Automated checks pass
- [x] Reviewer is selected when the PR is marked as ready for review
 
### 🔗 Jira Issue
Closes: [FREYA-914](https://scilifelab.atlassian.net/browse/FREYA-914)